### PR TITLE
Update Travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: node_js
+branches:
+  only:
+    - master
 node_js:
   - "stable"
   - "lts/*"
   - "10.10"
 cache:
   directories:
-    - client/node_modules
+    - "$HOME/.npm"
 before_install:
   - npm i -g npm@6.4.1
 before_script:
   - cd client
+  - npm ci
 script:
   - npm test
   - npm run build


### PR DESCRIPTION
Fixes #27: Travis Build is Failing

Our initial `.travis.yml` was failing sporadically due to the `node_modules` folder not being cached properly (_[see this SO post](https://stackoverflow.com/questions/42521884/should-i-have-travis-cache-node-modules-or-home-npm#answer-52387639)_).

We'll use `npm ci`, an alternative to `npm install` that is "_... meant to be used in automated environments such as test platforms, continuous integration, and deployment. It can be significantly faster than a regular npm install by skipping certain user-oriented features._"

We can also enable both items on the settings in Travis for this repo since we will only builds PR's and the `master` branch:

![image](https://user-images.githubusercontent.com/13009507/48521385-549f1f00-e842-11e8-8a5c-0822794fa135.png)

This means that any branches created by maintainers will not run prematurely in Travis (they'll have to open a PR for their patch).